### PR TITLE
fix: correct relative import in __init__.py

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -21,7 +21,7 @@ _current_dir = os.path.dirname(os.path.abspath(__file__))
 if _current_dir not in sys.path:
     sys.path.insert(0, _current_dir)
 
-from py.nodes import M3SongPlanner
+from .py.nodes import M3SongPlanner
 
 NODE_CLASS_MAPPINGS = {
     "M3SongPlanner": M3SongPlanner,


### PR DESCRIPTION
## Summary
Fixes #1: Correct Python relative import in `__init__.py` line 24.

## Change
- `from py.nodes import` → `from .py.nodes import`

The leading dot is required for proper intra-package relative imports in Python 2/3 compatible code.

## Testing
```python
# After fix - correct relative import
from .py.nodes import M3SongPlanner
```

Closes #1